### PR TITLE
feat: adaptation to btc signet

### DIFF
--- a/prover/src/dummy_service.rs
+++ b/prover/src/dummy_service.rs
@@ -84,7 +84,8 @@ impl DummyService {
                         header.time
                     );
                     let start_time: u32 = self.client.target_adjust_info.start_time().unpack();
-                    let next_target = calculate_next_target(curr_target, start_time, header.time);
+                    let next_target =
+                        calculate_next_target(curr_target, start_time, header.time, 0);
                     log::info!(">>> calculated new target  {next_target:#x}");
                     let next_bits = next_target.to_compact_lossy();
                     let next_target: core::Target = next_bits.into();

--- a/verifier/src/constants.rs
+++ b/verifier/src/constants.rs
@@ -1,3 +1,7 @@
 //! Constants.
 
-pub const FLAG_DISABLE_DIFFICULTY_CHECK: u8 = 0b1000_0000;
+// Constants for the chain type flag
+// Specifically utilizing the two highest bits for chain type identification
+pub const FLAG_CHAIN_TYPE_MAINNET: u8 = 0b0000_0000; // for mainnet
+pub const FLAG_CHAIN_TYPE_TESTNET: u8 = 0b1000_0000; // for testnet
+pub const FLAG_CHAIN_TYPE_SIGNET: u8 = 0b0100_0000; // for signet

--- a/verifier/src/tests/bitcoin.rs
+++ b/verifier/src/tests/bitcoin.rs
@@ -51,7 +51,8 @@ fn main_chain_targets_and_chainwork() {
             match (height + 1) % interval {
                 0 => {
                     assert!(prev_height + interval - 1 == height);
-                    let next_target = calculate_next_target(curr_target, start_time, header.time);
+                    let next_target =
+                        calculate_next_target(curr_target, start_time, header.time, 0);
                     log::info!(">>> calculated new target  {next_target:#x}");
                     next_bits = next_target.to_compact_lossy();
                     let next_target: Target = next_bits.into();

--- a/verifier/src/tests/mod.rs
+++ b/verifier/src/tests/mod.rs
@@ -6,6 +6,7 @@ use log::LevelFilter;
 mod bitcoin;
 
 pub(crate) mod data;
+pub(crate) mod signet;
 pub(crate) mod testnet;
 pub(crate) mod utilities;
 

--- a/verifier/src/tests/signet.rs
+++ b/verifier/src/tests/signet.rs
@@ -1,0 +1,83 @@
+use std::fs::read_to_string;
+
+use alloc::format;
+use ckb_jsonrpc_types::TransactionView;
+use ckb_types::packed::WitnessArgs;
+use serde_json::from_str as from_json_str;
+
+use crate::{
+    error::UpdateError,
+    molecule::prelude::*,
+    tests,
+    types::{
+        core,
+        packed::{SpvClient, SpvUpdate},
+        prelude::*,
+    },
+};
+
+// This case shows that:
+// - For the signet network, `header.bits` should be the same as `new_info.1`.
+// To run this test, use the following command:
+// `cargo test --package ckb-bitcoin-spv-verifier --lib -- tests::signet::signet_verify_new_client_error_197568 --exact --show-output`
+#[test]
+fn signet_verify_new_client_error_197568() {
+    let ret = verify_new_client_common(
+        "tx-0528-error-check-header-target-adjust-info.json",
+        1, // cell_dep_index
+    );
+    assert!(ret.is_err());
+}
+
+// This case shows that:
+// - For the signet network, target max should be Target::MAX_ATTAINABLE_SIGNET.
+// To run this test, use the following command:
+// `cargo test --package ckb-bitcoin-spv-verifier --lib -- tests::signet::signet_verify_new_client_error_header_197567 --exact --show-output`
+#[test]
+fn signet_verify_new_client_error_header_197567() {
+    let ret = verify_new_client_common(
+        "tx-0xd663a1dfdfbf9a4824950c44c0d5f5e65f6b1ba4710a0308edecadeaed3ac549.json",
+        2, // cell_dep_index
+    );
+    assert!(ret.is_err());
+}
+
+// To run this test, use the following command:
+// `cargo test --package ckb-bitcoin-spv-verifier --lib -- tests::signet::signet_verify_new_client_normal --exact --show-output`
+#[test]
+fn signet_verify_new_client_normal() {
+    let ret = verify_new_client_common(
+        "tx-0x01d827b049778ffb53532d8263009512a696647bde4acc7f10f39ded14c066ab.json",
+        2, // cell_dep_index
+    );
+    assert!(ret.is_ok());
+}
+
+fn verify_new_client_common(tx_file: &str, cell_dep_index: usize) -> Result<(), UpdateError> {
+    tests::setup();
+
+    let path = tests::data::find_bin_file("signet", tx_file);
+    let tx = read_to_string(path).unwrap();
+    let tx: TransactionView = from_json_str(&tx).unwrap();
+
+    let witnesses = tx.inner.witnesses;
+    let witness_args = WitnessArgs::from_slice(witnesses[0].as_bytes()).unwrap();
+    let spv_update_bin = witness_args.output_type().to_opt().unwrap().raw_data();
+    let spv_update = SpvUpdate::from_slice(&spv_update_bin).unwrap();
+
+    let client_bin = tx.inner.outputs_data[1].clone();
+    let client = SpvClient::from_slice(client_bin.as_bytes()).unwrap();
+
+    let cell_dep = tx.inner.cell_deps[cell_dep_index].out_point.clone();
+    let path =
+        tests::data::find_bin_file("signet", format!("tx-0x{}.json", cell_dep.tx_hash).as_str());
+    let previous_tx = read_to_string(path).unwrap();
+    let previous_tx: TransactionView = from_json_str(&previous_tx).unwrap();
+    let cell_dep_data_bin = &previous_tx.inner.outputs_data[cell_dep.index.value() as usize];
+    let cell_dep_client = SpvClient::from_slice(cell_dep_data_bin.as_bytes()).unwrap();
+
+    let mut cell_dep_client: core::SpvClient = cell_dep_client.unpack();
+    cell_dep_client.id = client.id().into();
+    let input_client = cell_dep_client.pack();
+    input_client.verify_new_client(&client, spv_update, 64)
+}

--- a/verifier/src/types/core.rs
+++ b/verifier/src/types/core.rs
@@ -23,7 +23,7 @@ pub use bitcoin_hashes::sha256d::Hash;
 pub use molecule::bytes::Bytes;
 pub use primitive_types::U256;
 
-use crate::types::packed;
+use crate::{constants::*, types::packed};
 
 //
 // Proofs
@@ -114,5 +114,24 @@ impl fmt::Display for SpvClient {
             "{{ id: {}, tip: {:#x}, mmr-root: {} }}",
             self.id, self.tip_block_hash, self.headers_mmr_root
         )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BitcoinChainType {
+    Mainnet,
+    Testnet,
+    Signet,
+    Other, // For future use.
+}
+
+impl From<u8> for BitcoinChainType {
+    fn from(flags: u8) -> Self {
+        match flags & 0b1100_0000 {
+            FLAG_CHAIN_TYPE_MAINNET => BitcoinChainType::Mainnet,
+            FLAG_CHAIN_TYPE_TESTNET => BitcoinChainType::Testnet,
+            FLAG_CHAIN_TYPE_SIGNET => BitcoinChainType::Signet,
+            _ => BitcoinChainType::Other,
+        }
     }
 }

--- a/verifier/src/types/extension/packed.rs
+++ b/verifier/src/types/extension/packed.rs
@@ -155,7 +155,6 @@ impl packed::SpvClient {
                     return Err(UpdateError::Difficulty);
                 }
             }
-
             // Check POW.
             new_tip_block_hash = header
                 .validate_pow(header.bits.into())


### PR DESCRIPTION
The btc signet has its own special definition of difficulty consensus, such as [powLimit](https://github.com/bitcoin/bitcoin/blob/v26.0/src/kernel/chainparams.cpp#L350), which is different from both maintain and testnet. 

In order to support btc signet spv with spv type contract, this pr will be realized by extending flags. Flags is the u8 data at the end of the spv client cells args.

The expanded Flags are as follows：

```rust
// Constants for the chain type flag
// Specifically utilizing the two highest bits for chain type identification
pub const FLAG_CHAIN_TYPE_MAINNET: u8 = 0b0000_0000; // for mainnet
pub const FLAG_CHAIN_TYPE_TESTNET: u8 = 0b1000_0000; // for testnet
pub const FLAG_CHAIN_TYPE_SIGNET: u8 = 0b0100_0000; // for signet
```

Compatibility Notes:

- For spv instance for testnet updated with this pr, spv service does not need to be upgraded.
- But for spv instance for signet to be deployed and updated, service needs to be updated to support signet as well (new pr will be submitted to service later)

---

Another modification is that POW should be checked regardless of chain type. Checking POW is the most important security for spv client on chain.

---

- [x] CI needs to wait for the following data to be uploaded before it can be passed through：

- https://github.com/ckb-cell/ckb-bitcoin-spv-testdata/pull/7